### PR TITLE
[mod] xml 수정

### DIFF
--- a/app/src/main/res/drawable/rounding_img.xml
+++ b/app/src/main/res/drawable/rounding_img.xml
@@ -2,5 +2,5 @@
 <!--@see https://jamie-dev.tistory.com/39-->
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <corners android:radius="13dp"/>
+    <corners android:radius="15dp"/>
 </shape>

--- a/app/src/main/res/drawable/selector_tab_menu_bg.xml
+++ b/app/src/main/res/drawable/selector_tab_menu_bg.xml
@@ -5,7 +5,7 @@
     <item android:state_selected="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/main"/>
-            <corners android:radius="15dp"/>
+            <corners android:radius="50dp"/>
         </shape>
     </item>
 

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -262,7 +262,7 @@
             android:fontFamily="@font/noto_sans_cjkkr_bold"
             android:textColor="@color/white"
             android:textSize="15dp"
-            tools:text="신청 사이트로 이동하기"
+            android:text="신청 사이트로 이동하기"
             style="?android:attr/borderlessButtonStyle"
             android:background="@color/main" />
     </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,7 +10,7 @@
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="35dp"
         android:paddingHorizontal="20dp"
         android:layout_marginVertical="20dp">
         <ImageButton
@@ -24,32 +24,32 @@
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tab_layout"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_gravity="center"
-            app:tabPaddingStart="0dp"
-            app:tabPaddingEnd="0dp"
-            app:tabContentStart="0dp"
-            android:clipToPadding="true"
+            app:tabPaddingTop="-10dp"
+            app:tabPaddingBottom="-10dp"
             app:tabGravity="center"
             app:tabMode="auto"
-            app:tabIndicator="@null">
+            app:tabIndicator="@null"
+            app:tabTextAppearance="@style/tab_text"
+            app:tabBackground="@drawable/selector_tab_menu_bg">
 
 <!-- TabItem을 커스텀하는 중이고, 추후 사용될 수 있으므로 주석처리해둠. -->
-<!--            <com.google.android.material.tabs.TabItem-->
-<!--                android:id="@+id/tab_1"-->
-<!--                android:layout_width="wrap_content"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:text="탭1"/>-->
-<!--            <com.google.android.material.tabs.TabItem-->
-<!--                android:id="@+id/tab_2"-->
-<!--                android:layout_width="wrap_content"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:text="탭2"/>-->
-<!--            <com.google.android.material.tabs.TabItem-->
-<!--                android:id="@+id/tab_3"-->
-<!--                android:layout_width="wrap_content"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:text="탭3"/>-->
+            <com.google.android.material.tabs.TabItem
+                android:id="@+id/recommend_tab"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="추천" />
+            <com.google.android.material.tabs.TabItem
+                android:id="@+id/general_tab"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="일반" />
+            <com.google.android.material.tabs.TabItem
+                android:id="@+id/scrap_tab"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="스크랩" />
         </com.google.android.material.tabs.TabLayout>
 
         <ImageButton

--- a/app/src/main/res/layout/filter_content_sort.xml
+++ b/app/src/main/res/layout/filter_content_sort.xml
@@ -29,20 +29,6 @@
             android:id="@+id/view_count_order"
             android:layout_width="90dp"
             android:layout_height="90dp"
-            android:layout_marginRight="30dp"
-            android:background="@drawable/selector_category_bg"
-            android:button="@null"
-            android:fontFamily="@font/noto_sans_cjkkr_bold"
-            android:gravity="center"
-            android:includeFontPadding="false"
-            android:text="조회순"
-            android:textColor="@drawable/selector_category_text_color"
-            android:textSize="15dp" />
-
-        <RadioButton
-            android:id="@+id/default_order"
-            android:layout_width="90dp"
-            android:layout_height="90dp"
             android:background="@drawable/selector_category_bg"
             android:button="@null"
             android:fontFamily="@font/noto_sans_cjkkr_bold"

--- a/app/src/main/res/layout/fragment_tap_recommend.xml
+++ b/app/src/main/res/layout/fragment_tap_recommend.xml
@@ -11,6 +11,7 @@
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="20dp">
         <TextView
+            android:id="@+id/category_textview"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
@@ -39,9 +40,10 @@
     </LinearLayout>
 
     <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="10dp"
-        android:layout_marginHorizontal="20dp"/>
+        android:layout_marginVertical="10dp"
+        android:layout_marginHorizontal="7.5dp"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_tap_scrap.xml
+++ b/app/src/main/res/layout/fragment_tap_scrap.xml
@@ -21,6 +21,7 @@
             android:textColor="@color/black"
             android:textSize="15dp" />
         <TextView
+            android:id="@+id/count"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
@@ -49,9 +50,10 @@
     </LinearLayout>
 
     <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginHorizontal="20dp"
-        android:layout_marginTop="10dp"/>
+        android:layout_marginVertical="10dp"
+        android:layout_marginHorizontal="7.5dp" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/item_bokji.xml
+++ b/app/src/main/res/layout/item_bokji.xml
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout
+    android:id="@+id/layout"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="7.5dp"
     android:background="@drawable/rounding_img">
 
     <ImageView
         android:id="@+id/thumbnail"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintDimensionRatio="1:1.5"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         android:foreground="@color/ultraSemiTransparent"
@@ -21,23 +24,22 @@
         android:id="@+id/title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_margin="15dp"
-        android:fontFamily="@font/noto_sans_cjkkr_black"
-        android:gravity="right"
+        android:padding="10dp"
+        android:fontFamily="@font/noto_sans_cjkkr_bold"
         android:includeFontPadding="false"
         android:textColor="@color/white"
-        android:textSize="20dp"
+        android:textSize="18dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         tools:text="건강보험료 할인" />
 
     <ImageButton
-        android:id="@+id/category"
+        android:id="@+id/scrap"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_margin="15dp"
+        android:layout_margin="10dp"
         android:background="@android:color/transparent"
-        android:src="@drawable/ic_scrap"
+        android:src="@drawable/ic_unscrap"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 


### PR DESCRIPTION
1. `rounding_img.xml `
   - radius를 13dp->15dp로 조정

2. `selector_tab_menu_bg.xml`
   - radius를 15dp->50dp로 조정

3. `activity_detail.xml`
   - tools:text-> android:text로 변경

4. `activity_main.xml`
   - tabItem 커스텀 문제 해결 (해결방법 : 글자 중앙에 위치하도록 패딩 수정)
   - TabLayout의 height를 wrap_content -> match_parent로 변경

5. `filter_content_sort.xml`
   - 조회순 2개 중복되는 것을 제거
   
6. `fragment_tap_recommend.xml`, `fragment_tap_scrap.xml`
  - margin 수정
  
7. `item_bokji.xml`
 - 타이틀 TextView의 위치를 우측하단에서 좌측하단으로 이동